### PR TITLE
Abstract syntax tree implementation

### DIFF
--- a/arML.opam
+++ b/arML.opam
@@ -14,6 +14,7 @@ depends: [
   "ocaml"
   "dune" {>= "3.8"}
   "bisect_ppx"
+  "ppx_deriving"
   "odoc" {with-doc}
 ]
 build: [

--- a/lib/ast/ast.ml
+++ b/lib/ast/ast.ml
@@ -53,3 +53,16 @@ type expression =
   | ERecLetIn of pattern * expression * expression (** Recursive let in: 'let rec f x = if x = 1 then 1 else x + f (x-1)'*)
   | ETyped of expression * type_defenition (** Assigning a type to an expression: (expr : int) *)
 [@@deriving show { with_path = false }]
+
+type declaration = 
+  | DOrdinary of pattern * expression (** Top-level let-binding: 'let f x = x' *)
+  | DRecursive of pattern * expression (** Top-level recursive let-binding: 'let rec f x = ...' *)
+[@@deriving show { with_path = false }]
+
+type structure_item =
+  | SExpression of expression (** Any expression: '5+3', 'let f x = x in f 0' *)
+  | SDeclaration of declaration (** Top-level non-recursive or recursive let-binding *)
+[@@deriving show { with_path = false }]
+
+type program = structure_item list [@@deriving show { with_path = false }]
+(** The entire parsed code of the program *)

--- a/lib/ast/ast.ml
+++ b/lib/ast/ast.ml
@@ -1,3 +1,13 @@
 (** Copyright 2024, raf-nr and ksenmel *)
 
 (** SPDX-License-Identifier: LGPL-3.0-or-later *)
+
+type identifier = string [@@deriving show { with_path = false }]
+
+type constant =
+  | CInt of int (** -1, 0, 1, ... *)
+  | CBool of bool (** true, false *)
+  | CChar of char (** 'a', 'b', 'c', ... *)
+  | CString of string (** "Hello world!" *)
+  | CUnit of unit (** () *)
+[@@deriving show { with_path = false }]

--- a/lib/ast/ast.ml
+++ b/lib/ast/ast.ml
@@ -12,6 +12,22 @@ type constant =
   | CUnit of unit (** () *)
 [@@deriving show { with_path = false }]
 
+type ground_type_defenition = 
+  | AInt (** Int type (x: int) *)
+  | ABool (** Bool type (x: bool) *)
+  | AUnit (** Unit type (x: unit) *)
+  | AChar (** Char type (x: char) *)
+  | AString (** String type (x: string) *)
+[@@deriving show { with_path = false }]
+
+type type_defenition =
+  | APolymorphic of identifier (* Polymorphic type (x: 'a) *)
+  | AGround of ground_type_defenition (* Int, Bool, Char, etc type *)
+  | AArrow of type_defenition * type_defenition (* Function type (f: (int -> int)) *)
+  | ATuple of type_defenition list (* Tuple type (x: (int, bool)) *)
+  | AList of type_defenition (* List type (x: int list) *)
+[@@deriving show { with_path = false }]
+
 type pattern =
   | PAny (* Wildcard: '_' *)
   | PNill (* Empty: '[]' *)

--- a/lib/ast/ast.ml
+++ b/lib/ast/ast.ml
@@ -11,3 +11,27 @@ type constant =
   | CString of string (** "Hello world!" *)
   | CUnit of unit (** () *)
 [@@deriving show { with_path = false }]
+
+type pattern =
+  | PAny (* Wildcard: '_' *)
+  | PNill (* Empty: '[]' *)
+  | PConst of constant (** Any constant: '1', 'true', etc *)
+  | PVar of identifier (** A variable pattern: 'x', 'y', etc *)
+  | POr of pattern * pattern (** 'P1 | P2' *)
+  | PTuple of pattern list (** Tuple of patterns: '(P1, P2, P3)' *)
+  | PListConstructor of pattern * pattern (** List construction pattern: 'P1::P2' *)
+[@@deriving show { with_path = false }]
+
+type expression =
+  | EConstant of constant (** Any constant: '1', 'true', etc *)
+  | EIdentifier of identifier (** A variable name: 'x', 'y', etc *)
+  | EFun of pattern list * expression (** Anonymous function: 'fun x -> x' *)
+  | EApplication of expression * expression list (** Application: f x *)
+  | EIfThenElse of expression * expression * expression option (* if condition then true_branch else false branch (else option)*)
+  | ETuple of expression list (** Tuple: '(E1, E2, ..., En)' *)
+  | EEmptyList (** Empty list: '[]' *)
+  | EListConstructor of expression * expression (** Contructor of list: 'hd :: md :: tl' *)
+  | EMatchWith of expression * (pattern * expression) list (** Pattern matching: match x with | y -> y *)
+  | ELetIn of pattern * expression * expression (** Let in: 'let f x = x in f 5 *)
+  | ERecLetIn of pattern * expression * expression (** Recursive let in: 'let rec f x = if x = 1 then 1 else x + f (x-1)'*)
+[@@deriving show { with_path = false }]

--- a/lib/ast/ast.ml
+++ b/lib/ast/ast.ml
@@ -1,0 +1,3 @@
+(** Copyright 2024, raf-nr and ksenmel *)
+
+(** SPDX-License-Identifier: LGPL-3.0-or-later *)

--- a/lib/ast/ast.ml
+++ b/lib/ast/ast.ml
@@ -36,6 +36,7 @@ type pattern =
   | POr of pattern * pattern (** 'P1 | P2' *)
   | PTuple of pattern list (** Tuple of patterns: '(P1, P2, P3)' *)
   | PListConstructor of pattern * pattern (** List construction pattern: 'P1::P2' *)
+  | EPattern of pattern * type_defenition (** Assigning a type to a pattern: (P : int) *)
 [@@deriving show { with_path = false }]
 
 type expression =
@@ -50,4 +51,5 @@ type expression =
   | EMatchWith of expression * (pattern * expression) list (** Pattern matching: match x with | y -> y *)
   | ELetIn of pattern * expression * expression (** Let in: 'let f x = x in f 5 *)
   | ERecLetIn of pattern * expression * expression (** Recursive let in: 'let rec f x = if x = 1 then 1 else x + f (x-1)'*)
+  | ETyped of expression * type_defenition (** Assigning a type to an expression: (expr : int) *)
 [@@deriving show { with_path = false }]

--- a/lib/ast/ast.mli
+++ b/lib/ast/ast.mli
@@ -53,3 +53,16 @@ type expression =
   | ERecLetIn of pattern * expression * expression (** Recursive let in: 'let rec f x = if x = 1 then 1 else x + f (x-1)'*)
   | ETyped of expression * type_defenition (** Assigning a type to an expression: (expr : int) *)
 [@@deriving show { with_path = false }]
+
+type declaration = 
+  | DOrdinary of pattern * expression (** Top-level let-binding: 'let f x = x' *)
+  | DRecursive of pattern * expression (** Top-level recursive let-binding: 'let rec f x = ...' *)
+[@@deriving show { with_path = false }]
+
+type structure_item =
+  | SExpression of expression (** Any expression: '5+3', 'let f x = x in f 0' *)
+  | SDeclaration of declaration (** Top-level non-recursive or recursive let-binding *)
+[@@deriving show { with_path = false }]
+
+type program = structure_item list [@@deriving show { with_path = false }]
+(** The entire parsed code of the program *)

--- a/lib/ast/ast.mli
+++ b/lib/ast/ast.mli
@@ -1,3 +1,37 @@
 (** Copyright 2024, raf-nr and ksenmel *)
 
 (** SPDX-License-Identifier: LGPL-3.0-or-later *)
+
+type identifier = string [@@deriving show { with_path = false }]
+
+type constant =
+  | CInt of int (** -1, 0, 1, ... *)
+  | CBool of bool (** true, false *)
+  | CChar of char (** 'a', 'b', 'c', ... *)
+  | CString of string (** "Hello world!" *)
+  | CUnit of unit (** () *)
+[@@deriving show { with_path = false }]
+
+type pattern =
+  | PAny (* Wildcard: '_' *)
+  | PNill (* Empty: '[]' *)
+  | PConst of constant (** Any constant: '1', 'true', etc *)
+  | PVar of identifier (** A variable pattern: 'x', 'y', etc *)
+  | POr of pattern * pattern (** 'P1 | P2' *)
+  | PTuple of pattern list (** Tuple of patterns: '(P1, P2, P3)' *)
+  | PListConstructor of pattern * pattern (** List construction pattern: 'P1::P2' *)
+[@@deriving show { with_path = false }]
+
+type expression =
+  | EConstant of constant (** Any constant: '1', 'true', etc *)
+  | EIdentifier of identifier (** A variable name: 'x', 'y', etc *)
+  | EFun of pattern list * expression (** Anonymous function: 'fun x -> x' *)
+  | EApplication of expression * expression list (** Application: f x *)
+  | EIfThenElse of expression * expression * expression option (* if condition then true_branch else false branch (else option)*)
+  | ETuple of expression list (** Tuple: '(E1, E2, ..., En)' *)
+  | EEmptyList (** Empty list: '[]' *)
+  | EListConstructor of expression * expression (** Contructor of list: 'hd :: md :: tl' *)
+  | EMatchWith of expression * (pattern * expression) list (** Pattern matching: match x with | y -> y *)
+  | ELetIn of pattern * expression * expression (** Let in: 'let f x = x in f 5 *)
+  | ERecLetIn of pattern * expression * expression (** Recursive let in: 'let rec f x = if x = 1 then 1 else x + f (x-1)'*)
+[@@deriving show { with_path = false }]

--- a/lib/ast/ast.mli
+++ b/lib/ast/ast.mli
@@ -12,6 +12,22 @@ type constant =
   | CUnit of unit (** () *)
 [@@deriving show { with_path = false }]
 
+type ground_type_defenition = 
+  | AInt (** Int type (x: int) *)
+  | ABool (** Bool type (x: bool) *)
+  | AUnit (** Unit type (x: unit) *)
+  | AChar (** Char type (x: char) *)
+  | AString (** String type (x: string) *)
+[@@deriving show { with_path = false }]
+
+type type_defenition =
+  | APolymorphic of identifier (* Polymorphic type (x: 'a) *)
+  | AGround of ground_type_defenition (* Int, Bool, Char, etc type *)
+  | AArrow of type_defenition * type_defenition (* Function type (f: (int -> int)) *)
+  | ATuple of type_defenition list (* Tuple type (x: (int, bool)) *)
+  | AList of type_defenition (* List type (x: int list) *)
+[@@deriving show { with_path = false }]
+
 type pattern =
   | PAny (* Wildcard: '_' *)
   | PNill (* Empty: '[]' *)

--- a/lib/ast/ast.mli
+++ b/lib/ast/ast.mli
@@ -1,0 +1,3 @@
+(** Copyright 2024, raf-nr and ksenmel *)
+
+(** SPDX-License-Identifier: LGPL-3.0-or-later *)

--- a/lib/ast/ast.mli
+++ b/lib/ast/ast.mli
@@ -36,6 +36,7 @@ type pattern =
   | POr of pattern * pattern (** 'P1 | P2' *)
   | PTuple of pattern list (** Tuple of patterns: '(P1, P2, P3)' *)
   | PListConstructor of pattern * pattern (** List construction pattern: 'P1::P2' *)
+  | EPattern of pattern * type_defenition (** Assigning a type to a pattern: (P : int) *)
 [@@deriving show { with_path = false }]
 
 type expression =
@@ -50,4 +51,5 @@ type expression =
   | EMatchWith of expression * (pattern * expression) list (** Pattern matching: match x with | y -> y *)
   | ELetIn of pattern * expression * expression (** Let in: 'let f x = x in f 5 *)
   | ERecLetIn of pattern * expression * expression (** Recursive let in: 'let rec f x = if x = 1 then 1 else x + f (x-1)'*)
+  | ETyped of expression * type_defenition (** Assigning a type to an expression: (expr : int) *)
 [@@deriving show { with_path = false }]

--- a/lib/ast/dune
+++ b/lib/ast/dune
@@ -1,0 +1,6 @@
+(library
+ (name ast)
+ (public_name arML.ast)
+ (modules Ast)
+ (preprocess
+  (pps ppx_deriving.show)))


### PR DESCRIPTION
The structure is implemented - an abstract syntax tree.
It consists of:
- types for representing simple constants (`5`, `'a'`, `true`, etc.);
- types for representing identifiers ('some_name');
- types for representing expression's and pattern's type declarations (`let f (x : int) = ...`);
- types for representing patterns during pattern matching and function arguments (`fun p1 p2 -> ...`);
- types for expressions (`fun`, `let ... in ...`, `if ... then ... else ...`, etc.);
- types for top-level let-bindings (`let f x = x`);
- program type (the whole steamed program - declarations list).