### PR TITLE
List expressions, mutual recursion and binary operations parser & type inference implementation

### DIFF
--- a/arML/lib/ast/ast.ml
+++ b/arML/lib/ast/ast.ml
@@ -48,6 +48,7 @@ and expression =
   | EApplication of expression * expression list (** Application: f x *)
   | EIfThenElse of expression * expression * expression option (* if condition then true_branch else false branch (else option)*)
   | ETuple of expression * expression * expression list (** Tuple: '(E1, E2, ..., En)' *)
+  | EListConstructor of expression * expression (** List construction: 1 :: 2 :: [] *)
   | EEmptyList (** Empty list: '[]' *)
   | EMatchWith of expression * case * case list (** Pattern matching: match x with | y -> y *)
   | ELetIn of case * expression (** Let in: 'let f x = x in f 5 *)

--- a/arML/lib/ast/ast.ml
+++ b/arML/lib/ast/ast.ml
@@ -51,14 +51,14 @@ and expression =
   | EListConstructor of expression * expression (** List construction: 1 :: 2 :: [] *)
   | EEmptyList (** Empty list: '[]' *)
   | EMatchWith of expression * case * case list (** Pattern matching: match x with | y -> y *)
-  | ELetIn of case * expression (** Let in: 'let f x = x in f 5 *)
-  | ERecLetIn of case * expression (** Recursive let in: 'let rec f x = if x = 1 then 1 else x + f (x-1)'*)
+  | ELetIn of case * case list * expression (** Let in: 'let f x = x in f 5 *)
+  | ERecLetIn of case * case list * expression (** Recursive let in: 'let rec f x = if x = 1 then 1 else x + f (x-1)'*)
   | ETyped of expression * type_defenition (** Assigning a type to an expression: (expr : int) *)
 [@@deriving show { with_path = false }]
 
 type declaration = 
-  | DOrdinary of case (** Top-level let-binding: 'let f x = x' *)
-  | DRecursive of case (** Top-level recursive let-binding: 'let rec f x = ...' *)
+  | DOrdinary of case * case list (** Top-level let-binding: 'let f x = x' *)
+  | DRecursive of case * case list (** Top-level recursive let-binding: 'let rec f x = ...' *)
 [@@deriving show { with_path = false }]
 
 type structure_item =

--- a/arML/lib/ast/ast.mli
+++ b/arML/lib/ast/ast.mli
@@ -48,6 +48,7 @@ and expression =
   | EApplication of expression * expression list (** Application: f x *)
   | EIfThenElse of expression * expression * expression option (* if condition then true_branch else false branch (else option)*)
   | ETuple of expression * expression * expression list (** Tuple: '(E1, E2, ..., En)' *)
+  | EListConstructor of expression * expression (** List construction: 1 :: 2 :: [] *)
   | EEmptyList (** Empty list: '[]' *)
   | EMatchWith of expression * case * case list (** Pattern matching: match x with | y -> y *)
   | ELetIn of case * expression (** Let in: 'let f x = x in f 5 *)

--- a/arML/lib/ast/ast.mli
+++ b/arML/lib/ast/ast.mli
@@ -51,14 +51,14 @@ and expression =
   | EListConstructor of expression * expression (** List construction: 1 :: 2 :: [] *)
   | EEmptyList (** Empty list: '[]' *)
   | EMatchWith of expression * case * case list (** Pattern matching: match x with | y -> y *)
-  | ELetIn of case * expression (** Let in: 'let f x = x in f 5 *)
-  | ERecLetIn of case * expression (** Recursive let in: 'let rec f x = if x = 1 then 1 else x + f (x-1)'*)
+  | ELetIn of case * case list * expression (** Let in: 'let f x = x in f 5 *)
+  | ERecLetIn of case * case list * expression (** Recursive let in: 'let rec f x = if x = 1 then 1 else x + f (x-1)'*)
   | ETyped of expression * type_defenition (** Assigning a type to an expression: (expr : int) *)
 [@@deriving show { with_path = false }]
 
 type declaration = 
-  | DOrdinary of case (** Top-level let-binding: 'let f x = x' *)
-  | DRecursive of case (** Top-level recursive let-binding: 'let rec f x = ...' *)
+  | DOrdinary of case * case list (** Top-level let-binding: 'let f x = x' *)
+  | DRecursive of case * case list (** Top-level recursive let-binding: 'let rec f x = ...' *)
 [@@deriving show { with_path = false }]
 
 type structure_item =

--- a/arML/lib/inferencer/dune
+++ b/arML/lib/inferencer/dune
@@ -10,7 +10,7 @@
   TypeErrors
   TypeUtils
   TypeEnv
-  CommonFunctions
+  InferBasic
   Schema
   Generalize
   Instantiate

--- a/arML/lib/inferencer/inferBasic.ml
+++ b/arML/lib/inferencer/inferBasic.ml
@@ -2,11 +2,12 @@
 
 (** SPDX-License-Identifier: LGPL-3.0-or-later *)
 
-open TypeTree
 open StateResultMonad
 open StateResultMonad.Syntax
+open TypeTree
 open TypeUtils
 
+(* Get a new type variable *)
 let fresh_var = fresh >>| fun name -> TVar name
 
 let infer_const = function

--- a/arML/lib/inferencer/inferDeclaration.ml
+++ b/arML/lib/inferencer/inferDeclaration.ml
@@ -4,11 +4,11 @@
 
 open StateResultMonad
 open StateResultMonad.Syntax
-open CommonFunctions
-open InferExpression
-open TypeErrors
 open TypeTree
+open TypeErrors
+open InferBasic
 open InferPattern
+open InferExpression
 
 let update_name_list name names_list = name :: List.filter (( <> ) name) names_list
 
@@ -22,18 +22,13 @@ let infer_declaration env name_list = function
         let generalized_ty = Generalize.generalize env ty in
         let new_names_list = update_name_list v name_list in
         return ((TypeEnv.extend env v generalized_ty), new_names_list)
-      | Ast.PTuple (p1, p2, ps), TypeTree.TTuple ts ->
-        (match ts with
-        | t1 :: t2 :: rest when List.length rest = List.length ps ->
+      | Ast.PTuple (p1, p2, ps), TypeTree.TTuple (t1 :: t2 :: rest) when List.length rest = List.length ps ->
           let* env, name_list = extend_env_with_pattern env name_list p1 t1 in
           let* env, name_list = extend_env_with_pattern env name_list p2 t2 in
           List.fold_left2 (fun acc pat ty ->
             let* env, name_list = acc in
             extend_env_with_pattern env name_list pat ty
           ) (return (env, name_list)) ps rest
-        | _ -> 
-          let* typ, _ = infer_pattern env pat in
-          fail @@ Unification_failed (typ, ty))
       | Ast.PAny, _
       | Ast.PNill, TypeTree.TList _ 
       | Ast.PConst(CUnit), TypeTree.TGround(GTUnit) -> return (env, name_list)
@@ -42,11 +37,15 @@ let infer_declaration env name_list = function
         fail @@ Unification_failed (typ, ty))
     in
 
+    (* Check several bounds *)
     let patterns = List.map fst cases in
     let* _ = UniquePatternVarsChecker.check_unique_vars patterns in
 
     List.fold_left (fun acc (pat, expr) ->
       let* extended_env, name_list = acc in
+      (* We specifically count in a “pure” env. 
+      This is not a mistake. There is no mutual recursion, 
+      each declaration in and cannot use the others.*)
       let* _, ty_expr = infer_expr env expr in
       let* extended_env, extend_name_list = extend_env_with_pattern extended_env name_list pat ty_expr in
       return (extended_env, extend_name_list)
@@ -55,6 +54,7 @@ let infer_declaration env name_list = function
   | Ast.DRecursive (case, cases) ->
     let cases = case :: cases in
 
+    (* Check several bounds *)
     let patterns = List.map fst cases in
     let* _ = UniquePatternVarsChecker.check_unique_vars patterns in
 

--- a/arML/lib/inferencer/inferPattern.ml
+++ b/arML/lib/inferencer/inferPattern.ml
@@ -23,7 +23,7 @@ let infer_pattern =
       let ty = TypeTree.TList fv in
       return (ty, env)
     | Ast.PTuple (first_pattern, second_pattern, patterns) as tuple_p ->
-      let* _ = check_unique_vars tuple_p in
+      let* _ = check_unique_vars [ tuple_p ] in
       (* Check several bounds *)
       let* ty, env =
         (* Here is the list of types in reverse order. *)
@@ -37,7 +37,7 @@ let infer_pattern =
       let ty = TypeTree.TTuple (List.rev ty) in
       return (ty, env)
     | Ast.PListConstructor (left, right) as list_cons ->
-      let* _ = check_unique_vars list_cons in
+      let* _ = check_unique_vars [ list_cons ] in
       (* Check several bounds *)
       let* ty1, env1 = helper env left in
       let* ty2, env2 = helper env1 right in

--- a/arML/lib/inferencer/inferPattern.ml
+++ b/arML/lib/inferencer/inferPattern.ml
@@ -4,8 +4,8 @@
 
 open StateResultMonad
 open StateResultMonad.Syntax
-open CommonFunctions
 open UniquePatternVarsChecker
+open InferBasic
 
 let infer_pattern =
   let rec helper env = function

--- a/arML/lib/inferencer/runner.ml
+++ b/arML/lib/inferencer/runner.ml
@@ -3,28 +3,28 @@
 (** SPDX-License-Identifier: LGPL-3.0-or-later *)
 
 open StateResultMonad
+open TypeUtils
 open InferExpression
 open InferProgram
-open TypeUtils
-
-let binary_ops = [
-  ("( + )", TGround GTInt @-> TGround GTInt @-> TGround GTInt);
-  ("( - )", TGround GTInt @-> TGround GTInt @-> TGround GTInt);
-  ("( * )", TGround GTInt @-> TGround GTInt @-> TGround GTInt);
-  ("( / )", TGround GTInt @-> TGround GTInt @-> TGround GTInt);
-  ("( % )", TGround GTInt @-> TGround GTInt @-> TGround GTInt);
-  ("( && )", TGround GTBool @-> TGround GTBool @-> TGround GTBool);
-  ("( || )", TGround GTBool @-> TGround GTBool @-> TGround GTBool);
-  ("( = )", TVar (-1) @-> TVar (-1) @-> TGround GTBool);
-  ("( > )", TVar (-1) @-> TVar (-1) @-> TGround GTBool);
-  ("( < )", TVar (-1) @-> TVar (-1) @-> TGround GTBool);
-  ("( >= )", TVar (-1) @-> TVar (-1) @-> TGround GTBool);
-  ("( <= )", TVar (-1) @-> TVar (-1) @-> TGround GTBool);
-  ("( != )", TVar (-1) @-> TVar (-1) @-> TGround GTBool);
-  ("( <> )", TVar (-1) @-> TVar (-1) @-> TGround GTBool);
-]
 
 let start_env =
+  let binary_ops = 
+    [ ("( + )", TGround GTInt @-> TGround GTInt @-> TGround GTInt)
+    ; ("( - )", TGround GTInt @-> TGround GTInt @-> TGround GTInt)
+    ; ("( * )", TGround GTInt @-> TGround GTInt @-> TGround GTInt)
+    ; ("( / )", TGround GTInt @-> TGround GTInt @-> TGround GTInt)
+    ; ("( % )", TGround GTInt @-> TGround GTInt @-> TGround GTInt)
+    ; ("( && )", TGround GTBool @-> TGround GTBool @-> TGround GTBool)
+    ; ("( || )", TGround GTBool @-> TGround GTBool @-> TGround GTBool)
+    ; ("( = )", TVar (-1) @-> TVar (-1) @-> TGround GTBool)
+    ; ("( > )", TVar (-1) @-> TVar (-1) @-> TGround GTBool)
+    ; ("( < )", TVar (-1) @-> TVar (-1) @-> TGround GTBool)
+    ; ("( >= )", TVar (-1) @-> TVar (-1) @-> TGround GTBool)
+    ; ("( <= )", TVar (-1) @-> TVar (-1) @-> TGround GTBool)
+    ; ("( != )", TVar (-1) @-> TVar (-1) @-> TGround GTBool)
+    ; ("( <> )", TVar (-1) @-> TVar (-1) @-> TGround GTBool)
+    ]
+  in
   List.fold_left
     (fun env (op, ty) -> TypeEnv.extend env op (Generalize.generalize TypeEnv.empty ty))
     TypeEnv.empty

--- a/arML/lib/inferencer/runner.ml
+++ b/arML/lib/inferencer/runner.ml
@@ -12,7 +12,16 @@ let binary_ops = [
   ("( - )", TGround GTInt @-> TGround GTInt @-> TGround GTInt);
   ("( * )", TGround GTInt @-> TGround GTInt @-> TGround GTInt);
   ("( / )", TGround GTInt @-> TGround GTInt @-> TGround GTInt);
-  ("( = )", TGround GTInt @-> TGround GTInt @-> TGround GTBool);
+  ("( % )", TGround GTInt @-> TGround GTInt @-> TGround GTInt);
+  ("( && )", TGround GTBool @-> TGround GTBool @-> TGround GTBool);
+  ("( || )", TGround GTBool @-> TGround GTBool @-> TGround GTBool);
+  ("( = )", TVar (-1) @-> TVar (-1) @-> TGround GTBool);
+  ("( > )", TVar (-1) @-> TVar (-1) @-> TGround GTBool);
+  ("( < )", TVar (-1) @-> TVar (-1) @-> TGround GTBool);
+  ("( >= )", TVar (-1) @-> TVar (-1) @-> TGround GTBool);
+  ("( <= )", TVar (-1) @-> TVar (-1) @-> TGround GTBool);
+  ("( != )", TVar (-1) @-> TVar (-1) @-> TGround GTBool);
+  ("( <> )", TVar (-1) @-> TVar (-1) @-> TGround GTBool);
 ]
 
 let start_env =

--- a/arML/lib/inferencer/solver/occursChecker.ml
+++ b/arML/lib/inferencer/solver/occursChecker.ml
@@ -8,9 +8,8 @@ open TypeTree
 let rec occurs_check v = function
   | TVar b -> b = v
   | TArr (left, right) -> occurs_check v left || occurs_check v right
-  (* | TList typ -> occurs_in v typ
+  | TList typ -> occurs_check v typ
   | TTuple typ_list ->
-    List.fold_left (fun acc item -> acc || occurs_in v item) false typ_list *)
+    List.fold_left (fun acc item -> acc || occurs_check v item) false typ_list
   | TGround _ -> false
-  | _ -> false
 ;;

--- a/arML/lib/inferencer/solver/substitution.ml
+++ b/arML/lib/inferencer/solver/substitution.ml
@@ -47,6 +47,7 @@ let rec unify l r =
     let* sub1 = unify left1 left2 in
     let* sub2 = unify (apply sub1 right1) (apply sub1 right2) in
     compose sub1 sub2
+  | TList typ1, TList typ2 -> unify typ1 typ2
   | TTuple t_list1, TTuple t_list2 ->
     (match
         Base.List.fold2 t_list1 t_list2 ~init:(return empty) ~f:(fun acc it1 it2 ->

--- a/arML/lib/inferencer/solver/uniquePatternVarsChecker.ml
+++ b/arML/lib/inferencer/solver/uniquePatternVarsChecker.ml
@@ -25,7 +25,7 @@ let check_unique_vars patterns =
     | Ast.PListConstructor (hd, tl) :: rest ->
       let* var_set = helper var_set [hd] in
       helper var_set (tl :: rest)
-    | _ :: rest -> helper var_set rest
+    | Ast.PTyped (pat, _) :: rest -> helper var_set (pat :: rest)
   in
   helper VarSet.empty patterns
 ;;

--- a/arML/lib/inferencer/solver/uniquePatternVarsChecker.ml
+++ b/arML/lib/inferencer/solver/uniquePatternVarsChecker.ml
@@ -3,25 +3,29 @@
 (** SPDX-License-Identifier: LGPL-3.0-or-later *)
 
 open StateResultMonad
+open StateResultMonad.Syntax
 open TypeTree
 open TypeErrors
 
-let check_unique_vars pattern =
-  (* Checks that all variables in the pattern are unique.
-     Used to detect severeal bound errors in tuple patterns,
+let check_unique_vars patterns =
+  (* Checks that all variables in the given list of patterns are unique.
+     Used to detect several bound errors in tuple patterns,
      list constructor patterns, and effects with arguments. *)
   let rec helper var_set = function
-    | Ast.PVar (Id v) ->
+    | [] -> return var_set
+    | Ast.PVar (Id v) :: rest ->
       if VarSet.mem v var_set
-      then
-        (* If at least one variable is found twice, we raise an error. *)
-        fail (Several_bounds v)
-      else return (VarSet.add v var_set)
-    | Ast.PAny -> return var_set
-    | Ast.PNill -> return var_set
-    | Ast.PConst _ -> return var_set
-    | Ast.PTuple (fst, snd, other) -> RList.fold_left (fst :: snd :: other) ~init:(return var_set) ~f:helper
-    | _ -> return var_set (* !!!!!! *)
+      then fail (Several_bounds v)
+      else helper (VarSet.add v var_set) rest
+    | Ast.PAny :: rest -> helper var_set rest
+    | Ast.PNill :: rest -> helper var_set rest
+    | Ast.PConst _ :: rest -> helper var_set rest
+    | Ast.PTuple (fst, snd, other) :: rest ->
+      helper var_set (fst :: snd :: other @ rest)
+    | Ast.PListConstructor (hd, tl) :: rest ->
+      let* var_set = helper var_set [hd] in
+      helper var_set (tl :: rest)
+    | _ :: rest -> helper var_set rest
   in
-  helper VarSet.empty pattern
+  helper VarSet.empty patterns
 ;;

--- a/arML/lib/inferencer/type/typeEnv.ml
+++ b/arML/lib/inferencer/type/typeEnv.ml
@@ -6,6 +6,7 @@ open StateResultMonad
 open StateResultMonad.Syntax
 open TypeTree
 
+(* Type environment is mapping top-level identifiers to their schema type *)
 type t = (string, Schema.schema, Base.String.comparator_witness) Base.Map.t
 
 let empty : t = Base.Map.empty (module Base.String)
@@ -23,6 +24,7 @@ let extend env key schema = Base.Map.update ~f:(fun _ -> schema) env key
 
 let find env key = Base.Map.find env key
 
+(* Search for an identifier in the environment. If not found - error. *)
 let lookup_env env name =
   match find env name with
   | Some schema ->

--- a/arML/lib/parser/common.ml
+++ b/arML/lib/parser/common.ml
@@ -10,6 +10,7 @@ open Ast
 type dispatch =
   { parse_tuple : dispatch -> expression Angstrom.t
   ; parse_list : dispatch -> expression Angstrom.t
+  ; parse_list_constructor : dispatch -> expression Angstrom.t
   ; parse_fun : dispatch -> expression Angstrom.t
   ; parse_function : dispatch -> expression Angstrom.t
   ; parse_application : dispatch -> expression Angstrom.t

--- a/arML/lib/parser/common.ml
+++ b/arML/lib/parser/common.ml
@@ -9,6 +9,7 @@ open Ast
 
 type dispatch =
   { parse_tuple : dispatch -> expression Angstrom.t
+  ; parse_list : dispatch -> expression Angstrom.t
   ; parse_fun : dispatch -> expression Angstrom.t
   ; parse_function : dispatch -> expression Angstrom.t
   ; parse_application : dispatch -> expression Angstrom.t

--- a/arML/lib/parser/common.ml
+++ b/arML/lib/parser/common.ml
@@ -53,6 +53,11 @@ let is_acceptable_service_char = function
   | _ -> false
 ;; 
 
+let is_operator_char = function
+  | '+' | '-' | '*' | '/' | '=' | '<' | '>' | '!' | '&' | '|' | '^' | '%' -> true
+  | _ -> false
+;;
+
 let is_keyword = function
   | "let"
   | "if"
@@ -89,7 +94,7 @@ let rec chainr1 e op = e >>= fun a -> op >>= (fun f -> chainr1 e op >>| f a) <|>
 let skip_wspace = skip_while is_whitespace
 let skip_wspace1 = take_while1 is_whitespace
 
-let parens p = skip_wspace *> char '(' *> p <* skip_wspace <* char ')'
+let parens p = skip_wspace *> char '(' *> skip_wspace *> p <* skip_wspace <* char ')'
 let brackets p = skip_wspace *> char '[' *> p <* skip_wspace <* char ']'
 
 let arrow = skip_wspace *> string "->"
@@ -145,6 +150,11 @@ let parse_identifier =
   if is_keyword name
   then fail "Syntax error: keywords cannot be used as identifiers"
   else return @@ Id name
+;;
+
+let parse_operator =
+  let* operator = parens (take_while1 is_operator_char) in
+  return @@ Id ("( " ^ operator ^ " )")
 ;;
 
 (* ---------------- *)

--- a/arML/lib/parser/declaration.ml
+++ b/arML/lib/parser/declaration.ml
@@ -11,7 +11,8 @@ open Type
 let parse_declaration p =
   let parse_expr =
     choice 
-      [ p.parse_binary_operation p
+      [ p.parse_list_constructor p
+      ; p.parse_binary_operation p
       ; p.parse_type_defition p
       ; p.parse_list p
       ; p.parse_application p

--- a/arML/lib/parser/declaration.ml
+++ b/arML/lib/parser/declaration.ml
@@ -13,6 +13,7 @@ let parse_declaration p =
     choice 
       [ p.parse_binary_operation p
       ; p.parse_type_defition p
+      ; p.parse_list p
       ; p.parse_application p
       ; p.parse_tuple p
       ; p.parse_fun p

--- a/arML/lib/parser/expression.ml
+++ b/arML/lib/parser/expression.ml
@@ -19,7 +19,7 @@ let parse_constant_expr =
 (* Identifiers expression parsers *)
 
 let parse_identifier_expr =
-  let* identifier = parse_identifier in
+  let* identifier = parse_identifier <|> parse_operator in
   return @@ EIdentifier identifier
 
 (* ---------------- *)

--- a/arML/lib/parser/pattern.ml
+++ b/arML/lib/parser/pattern.ml
@@ -30,7 +30,7 @@ let parse_constant_pattern =
 (* Identifiers pattern parsers *)
 
 let parse_identifier_pattern =
-  let* identifier = parse_identifier in
+  let* identifier = parse_identifier <|> parse_operator in
   return @@ PVar identifier
 
 (* ---------------- *)

--- a/arML/lib/parser/runner.ml
+++ b/arML/lib/parser/runner.ml
@@ -22,6 +22,7 @@ let parsers =
   ; parse_match_with
   ; parse_function
   ; parse_tuple
+  ; parse_list
   ; parse_empty_list_expr
   }
 ;;
@@ -29,6 +30,7 @@ let parsers =
 let parse_expression = skip_wspace *> choice 
   [ parsers.parse_type_defition parsers
   ; parsers.parse_binary_operation parsers
+  ; parsers.parse_list parsers
   ; parsers.parse_application parsers
   ; parsers.parse_tuple parsers
   ; parsers.parse_constant_expr

--- a/arML/lib/parser/runner.ml
+++ b/arML/lib/parser/runner.ml
@@ -23,12 +23,14 @@ let parsers =
   ; parse_function
   ; parse_tuple
   ; parse_list
+  ; parse_list_constructor
   ; parse_empty_list_expr
   }
 ;;
 
 let parse_expression = skip_wspace *> choice 
   [ parsers.parse_type_defition parsers
+  ; parsers.parse_list_constructor parsers
   ; parsers.parse_binary_operation parsers
   ; parsers.parse_list parsers
   ; parsers.parse_application parsers


### PR DESCRIPTION
- Parser and type inference for list expressions. Example: `let x = 1 :: [2 ; 3]`.
- Parser and type inference for `let ... and` declaration and expression. Examples: `let x = 1 and y = 2`, `let rec f x = g x and g x = f x`, `let (x, y) = (1, 2) and (z, w) = (3, 4) in x + y + z + w`.
- Type inference for expressions with the following binary operations: `+`, `-`, `*`, `/`, `%`, `&&`, `||`, `=`, `>`, `<`, `>=`, `<=`, `!=`, `(<>)`.